### PR TITLE
Support APNS Notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,7 @@ playground.xcworkspace
 # you should judge for yourself, the pros and cons are mentioned at:
 # https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
 #
-# Pods/
+Pods/
 
 # Carthage
 #

--- a/FlyBuy Example.xcodeproj/project.pbxproj
+++ b/FlyBuy Example.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -62,6 +62,7 @@
 		2BFE3CBF22E8C4B1005B9591 /* OrdersViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersViewController.swift; sourceTree = "<group>"; };
 		2BFE3CC122E8CA27005B9591 /* orders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = orders.swift; sourceTree = "<group>"; };
 		3DE27AE569CF9A327D5E516D /* Pods-FlyBuy Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FlyBuy Example.release.xcconfig"; path = "Target Support Files/Pods-FlyBuy Example/Pods-FlyBuy Example.release.xcconfig"; sourceTree = "<group>"; };
+		6184FA1E24B4D35800C8B2C8 /* FlyBuy Example.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "FlyBuy Example.entitlements"; sourceTree = "<group>"; };
 		97AB1D38C784685BF94D7728 /* Pods-FlyBuy Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FlyBuy Example.debug.xcconfig"; path = "Target Support Files/Pods-FlyBuy Example/Pods-FlyBuy Example.debug.xcconfig"; sourceTree = "<group>"; };
 		D856F56C58594BC9E3C29A21 /* Pods_FlyBuy_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FlyBuy_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -158,6 +159,7 @@
 		2BA15DC022E0E3AA000DF9BE /* FlyBuy Example */ = {
 			isa = PBXGroup;
 			children = (
+				6184FA1E24B4D35800C8B2C8 /* FlyBuy Example.entitlements */,
 				2BD3DD5224216B2F000F06F5 /* FlyBuy.framework */,
 				2BFE3CBE22E8C18D005B9591 /* Libraries */,
 				2B226FB922E775C7006A6F92 /* Assets */,
@@ -184,7 +186,6 @@
 				97AB1D38C784685BF94D7728 /* Pods-FlyBuy Example.debug.xcconfig */,
 				3DE27AE569CF9A327D5E516D /* Pods-FlyBuy Example.release.xcconfig */,
 			);
-			name = Pods;
 			path = Pods;
 			sourceTree = "<group>";
 		};
@@ -467,6 +468,7 @@
 			baseConfigurationReference = 97AB1D38C784685BF94D7728 /* Pods-FlyBuy Example.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = "FlyBuy Example/FlyBuy Example.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "FlyBuy\\ Example/FlyBuy.framework";
 				DEVELOPMENT_TEAM = DF6DBXCH9A;
@@ -492,6 +494,7 @@
 			baseConfigurationReference = 3DE27AE569CF9A327D5E516D /* Pods-FlyBuy Example.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = "FlyBuy Example/FlyBuy Example.entitlements";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "FlyBuy\\ Example/FlyBuy.framework";
 				DEVELOPMENT_TEAM = DF6DBXCH9A;

--- a/FlyBuy Example.xcodeproj/project.pbxproj
+++ b/FlyBuy Example.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		2BD3DD5524216B3A000F06F5 /* FlyBuy.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 2BD3DD5224216B2F000F06F5 /* FlyBuy.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		2BFE3CC022E8C4B1005B9591 /* OrdersViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BFE3CBF22E8C4B1005B9591 /* OrdersViewController.swift */; };
 		2BFE3CC222E8CA27005B9591 /* orders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BFE3CC122E8CA27005B9591 /* orders.swift */; };
+		97C11A8EA4060F8124E3AF77 /* Pods_FlyBuy_Example.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D856F56C58594BC9E3C29A21 /* Pods_FlyBuy_Example.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -60,6 +61,9 @@
 		2BD3DD5224216B2F000F06F5 /* FlyBuy.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = FlyBuy.framework; sourceTree = "<group>"; };
 		2BFE3CBF22E8C4B1005B9591 /* OrdersViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersViewController.swift; sourceTree = "<group>"; };
 		2BFE3CC122E8CA27005B9591 /* orders.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = orders.swift; sourceTree = "<group>"; };
+		3DE27AE569CF9A327D5E516D /* Pods-FlyBuy Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FlyBuy Example.release.xcconfig"; path = "Target Support Files/Pods-FlyBuy Example/Pods-FlyBuy Example.release.xcconfig"; sourceTree = "<group>"; };
+		97AB1D38C784685BF94D7728 /* Pods-FlyBuy Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-FlyBuy Example.debug.xcconfig"; path = "Target Support Files/Pods-FlyBuy Example/Pods-FlyBuy Example.debug.xcconfig"; sourceTree = "<group>"; };
+		D856F56C58594BC9E3C29A21 /* Pods_FlyBuy_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_FlyBuy_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -68,6 +72,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2BD3DD5424216B3A000F06F5 /* FlyBuy.framework in Frameworks */,
+				97C11A8EA4060F8124E3AF77 /* Pods_FlyBuy_Example.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -127,6 +132,7 @@
 			isa = PBXGroup;
 			children = (
 				2B69C1E2234664D600F96760 /* FlyBuy.framework */,
+				D856F56C58594BC9E3C29A21 /* Pods_FlyBuy_Example.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -137,6 +143,7 @@
 				2BA15DC022E0E3AA000DF9BE /* FlyBuy Example */,
 				2BA15DBF22E0E3AA000DF9BE /* Products */,
 				2B63310122F0EDA400C1814A /* Frameworks */,
+				3A98BF1D679B05ED1BF9D87B /* Pods */,
 			);
 			sourceTree = "<group>";
 		};
@@ -171,6 +178,16 @@
 			path = Libraries;
 			sourceTree = "<group>";
 		};
+		3A98BF1D679B05ED1BF9D87B /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				97AB1D38C784685BF94D7728 /* Pods-FlyBuy Example.debug.xcconfig */,
+				3DE27AE569CF9A327D5E516D /* Pods-FlyBuy Example.release.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -178,10 +195,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 2BA15DD022E0E3AB000DF9BE /* Build configuration list for PBXNativeTarget "FlyBuy Example" */;
 			buildPhases = (
+				2315E797C66E6F628BD5B20A /* [CP] Check Pods Manifest.lock */,
 				2BA15DBA22E0E3AA000DF9BE /* Sources */,
 				2BA15DBB22E0E3AA000DF9BE /* Frameworks */,
 				2BA15DBC22E0E3AA000DF9BE /* Resources */,
 				2BD3DD3D24216327000F06F5 /* Embed Frameworks */,
+				936BE05D423525049ACE286D /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -242,6 +261,48 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		2315E797C66E6F628BD5B20A /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-FlyBuy Example-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		936BE05D423525049ACE286D /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-FlyBuy Example/Pods-FlyBuy Example-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-FlyBuy Example/Pods-FlyBuy Example-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-FlyBuy Example/Pods-FlyBuy Example-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		2BA15DBA22E0E3AA000DF9BE /* Sources */ = {
@@ -403,6 +464,7 @@
 		};
 		2BA15DD122E0E3AB000DF9BE /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 97AB1D38C784685BF94D7728 /* Pods-FlyBuy Example.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;
@@ -427,6 +489,7 @@
 		};
 		2BA15DD222E0E3AB000DF9BE /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 3DE27AE569CF9A327D5E516D /* Pods-FlyBuy Example.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_STYLE = Automatic;

--- a/FlyBuy Example.xcworkspace/contents.xcworkspacedata
+++ b/FlyBuy Example.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:FlyBuy Example.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/FlyBuy Example.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/FlyBuy Example.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/FlyBuy Example/AppDelegate.swift
+++ b/FlyBuy Example/AppDelegate.swift
@@ -14,14 +14,22 @@ import CoreLocation
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
-  let gcmMessageIDKey = "gcm.message_id"
   var window: UIWindow?
+  let gcmMessageIDKey = "gcm.message_id"
 
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+
+    CLLocationManager().requestWhenInUseAuthorization()
     
-    let token = "97.eHzCUMApgzRNM5bqjQ6HWRqB"
+    //setupFirebase()
+    registerForNotifications()
+    registerForSDKLocationNotifications()
+    
+    let token = "<YOUR TOKEN HERE>"
     assert(token != "<YOUR TOKEN HERE>", "You must add your FlyBuy token")
     FlyBuy.configure(["token": token])
+
+    checkFlyBuyConfig()
     
     FlyBuy.sites.fetch(page: 1) { (sites, pagination, error) -> (Void) in
         NSLog("Sites have been fetched")
@@ -29,162 +37,224 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     return true
   }
-  
-  func applicationWillResignActive(_ application: UIApplication) {
-    // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
-    // Use this method to pause ongoing tasks, disable timers, and invalidate graphics rendering callbacks. Games should use this method to pause the game.
+
+    func applicationWillResignActive(_ application: UIApplication) {
+      // Sent when the application is about to move from active to inactive
+      // state. This can occur for certain types of temporary interruptions (such
+      // as an incoming phone call or SMS message) or when the user quits the
+      // application and it begins the transition to the background state.
+      //
+      // Use this method to pause ongoing tasks, disable timers, and invalidate
+      // graphics rendering callbacks. Games should use this method to pause the
+      // game.
+    }
+
+    func applicationDidEnterBackground(_ application: UIApplication) {
+      // Use this method to release shared resources, save user data, invalidate
+      // timers, and store enough application state information to restore your
+      // application to its current state in case it is terminated later.
+      //
+      // If your application supports background execution, this method is called
+      // instead of applicationWillTerminate: when the user quits.
+    }
+
+    func applicationWillEnterForeground(_ application: UIApplication) {
+      // Called as part of the transition from the background to the active
+      // state; here you can undo many of the changes made on entering the
+      // background.
+    }
+
+    func applicationDidBecomeActive(_ application: UIApplication) {
+      // Restart any tasks that were paused (or not yet started) while the
+      // application was inactive. If the application was previously in the
+      // background, optionally refresh the user interface.
+    }
+
+    func applicationWillTerminate(_ application: UIApplication) {
+      // Called when the application is about to terminate. Save data if
+      // appropriate. See also applicationDidEnterBackground:.
+    }
+
+    func application(_ application: UIApplication,
+                     didReceiveRemoteNotification userInfo: [AnyHashable: Any],
+                     fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void) {
+      // If you are receiving a notification message while your app is in the
+      // background, this callback will not be fired till the user taps on the
+      // notification launching the application.
+
+      FlyBuy.handleRemoteNotification(userInfo)
+
+      // Since we disable swizzling with Firebase you must let Messaging know
+      // about the message, for Analytics
+      // Messaging.messaging().appDidReceiveMessage(userInfo)
+
+      // Print message ID.
+      if let messageID = userInfo[gcmMessageIDKey] {
+        print("Message ID: \(messageID)")
+      }
+
+      // Print full message.
+      print(userInfo)
+
+      completionHandler(UIBackgroundFetchResult.newData)
+    }
+
+    func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
+      print("Unable to register for remote notifications: \(error.localizedDescription)")
+    }
+
+    // Since we disable swizzling with Firebase this function must be implemented
+    // so that the APNs token can be paired to the FCM registration token.
+    func application(_ application: UIApplication,
+                     didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+      Messaging.messaging().apnsToken = deviceToken
+      let tokenParts = deviceToken.map { data in String(format: "%02.2hhx", data) }
+      let token = tokenParts.joined()
+      print("Device Token: \(token)")
+    }
   }
 
-  func applicationDidEnterBackground(_ application: UIApplication) {
-    // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
-    // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
-  }
+  extension AppDelegate {
+    func useStagingAPIEndpoint() {
+      UserDefaultsKey.apiBase.set(value: "https://flybuy-staging.radiusnetworks.com")
+    }
 
-  func applicationWillEnterForeground(_ application: UIApplication) {
-    // Called as part of the transition from the background to the active state; here you can undo many of the changes made on entering the background.
-  }
+    func checkAppUpgradeURL(_ error: Error?) {
+      if let error = error as? FlyBuyAPIError, error.statusCode == .appUpgradeRequired {
+        checkFlyBuyConfig()
+      }
+    }
 
-  func applicationDidBecomeActive(_ application: UIApplication) {
-    // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
-  }
+    func checkFlyBuyConfig() {
+      FlyBuy.config.fetch() { (config, error) in
+        if let upgradeSettings = config?["upgrade"] as? [String : Any],
+          let required = upgradeSettings["required"] as? Bool,
+          let urlStr = upgradeSettings["url"] as? String, let url = URL(string: urlStr),
+          let message = upgradeSettings["message"] as? String {
+            self.upgradeAlert(required: required, message: message, url: url)
+        }
+      }
+    }
 
-  func applicationWillTerminate(_ application: UIApplication) {
-    // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
-  }
+    func upgradeAlert(required: Bool, message: String, url: URL) {
+      let alert = UIAlertController(title: "New Version Available", message: message, preferredStyle: .actionSheet)
+      alert.addAction(UIAlertAction(title: "Update App", style: .default, handler: { (action) in
+        UIApplication.shared.open(url, options: [:], completionHandler: nil)
+      }))
+      alert.addAction(UIAlertAction(title: "Not Now", style: .cancel))
+      if let topController = UIApplication.shared.keyWindow?.rootViewController {
+        DispatchQueue.main.async {
+          topController.present(alert, animated: true, completion: nil)
+        }
+      }
+    }
 
+    func setupFirebase() {
+      FirebaseApp.configure()
+      UNUserNotificationCenter.current().delegate = self
+      Messaging.messaging().delegate = self
+      Messaging.messaging().shouldEstablishDirectChannel = true
+    }
 
-}
+    // Register for remote notifications. This shows a permission dialog on first run, to
+    // show the dialog at a more appropriate time move this registration accordingly.
+    func registerForNotifications(_ callback: ((Bool, Error?) -> (Void))? = nil) {
 
-extension AppDelegate {
-  func checkFlyBuyConfig() {
-    FlyBuy.config.fetch() { (config, error) in
-      if let upgradeSettings = config?["upgrade"] as? [String : Any],
-        let required = upgradeSettings["required"] as? Bool,
-        let urlStr = upgradeSettings["url"] as? String, let url = URL(string: urlStr),
-        let message = upgradeSettings["message"] as? String {
-          self.upgradeAlert(required: required, message: message, url: url)
+      let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound]
+      UNUserNotificationCenter.current().requestAuthorization(options: authOptions) { (granted, error) in
+        DispatchQueue.main.async { callback?(granted, error) }
+      }
+
+      UIApplication.shared.registerForRemoteNotifications()
+
+      InstanceID.instanceID().instanceID { (result, error) in
+        if let error = error {
+          print("Error fetching remote instance ID: \(error)")
+        } else if let result = result {
+          print("Remote instance ID token: \(result.token)")
+        }
+      }
+    }
+
+    func registerForSDKLocationNotifications() {
+      NotificationCenter.default.addObserver(self, selector: #selector(sdkLocationNotification(notification:)), name: .locationAuthorizationNotDetermined, object: nil)
+      NotificationCenter.default.addObserver(self, selector: #selector(sdkLocationNotification(notification:)), name: .locationNotAuthorized, object: nil)
+    }
+    
+    @objc func sdkLocationNotification(notification: Notification) {
+      switch notification.name {
+      case .locationAuthorizationNotDetermined:
+        // We should have already asked for location authorization after presenting
+        // the "consent" screen during a redeem flow. But the SDK is telling us we
+        // haven't asked, so let's ask now.
+        CLLocationManager().requestWhenInUseAuthorization()
+
+      case .locationNotAuthorized:
+        NSLog("App is not authorized to receive location updates")
+        
+      default: ()
       }
     }
   }
 
-  func upgradeAlert(required: Bool, message: String, url: URL) {
-    let alert = UIAlertController(title: "New Version Available", message: message, preferredStyle: .actionSheet)
-    alert.addAction(UIAlertAction(title: "Update App", style: .default, handler: { (action) in
-      UIApplication.shared.open(url, options: [:], completionHandler: nil)
-    }))
-    alert.addAction(UIAlertAction(title: "Not Now", style: .cancel))
-    if let topController = UIApplication.shared.keyWindow?.rootViewController {
-      DispatchQueue.main.async {
-        topController.present(alert, animated: true, completion: nil)
+  extension AppDelegate : UNUserNotificationCenterDelegate {
+
+    // Receive displayed notifications for iOS 10 devices.
+    func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                willPresent notification: UNNotification,
+                                withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+      let userInfo = notification.request.content.userInfo
+
+      // With swizzling disabled you must let Messaging know about the message, for Analytics
+      Messaging.messaging().appDidReceiveMessage(userInfo)
+
+      // Print message ID.
+      if let messageID = userInfo[gcmMessageIDKey] {
+        print("Message ID: \(messageID)")
       }
-    }
-  }
 
-  func setupFirebase() {
-    FirebaseApp.configure()
-    UNUserNotificationCenter.current().delegate = self
-    Messaging.messaging().delegate = self
-    Messaging.messaging().shouldEstablishDirectChannel = true
-  }
+      // Print full message.
+      print(userInfo)
 
-  // Register for remote notifications. This shows a permission dialog on first run, to
-  // show the dialog at a more appropriate time move this registration accordingly.
-  func registerForNotifications(_ callback: ((Bool, Error?) -> (Void))? = nil) {
-
-    let authOptions: UNAuthorizationOptions = [.alert, .badge, .sound]
-    UNUserNotificationCenter.current().requestAuthorization(options: authOptions) { (granted, error) in
-      DispatchQueue.main.async { callback?(granted, error) }
+      completionHandler([.badge, .sound, .alert])
     }
 
-    UIApplication.shared.registerForRemoteNotifications()
+    func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                didReceive response: UNNotificationResponse,
+                                withCompletionHandler completionHandler: @escaping () -> Void) {
+      let userInfo = response.notification.request.content.userInfo
 
-    InstanceID.instanceID().instanceID { (result, error) in
-      if let error = error {
-        print("Error fetching remote instance ID: \(error)")
-      } else if let result = result {
-        print("Remote instance ID token: \(result.token)")
+      // Print message ID.
+      if let messageID = userInfo[gcmMessageIDKey] {
+        print("Message ID: \(messageID)")
       }
+
+      // Print full message.
+      print(userInfo)
+
+      completionHandler()
     }
   }
 
-  func registerForSDKLocationNotifications() {
-    NotificationCenter.default.addObserver(self, selector: #selector(sdkLocationNotification(notification:)), name: .locationAuthorizationNotDetermined, object: nil)
-    NotificationCenter.default.addObserver(self, selector: #selector(sdkLocationNotification(notification:)), name: .locationNotAuthorized, object: nil)
-  }
-  
-  @objc func sdkLocationNotification(notification: Notification) {
-    switch notification.name {
-    case .locationAuthorizationNotDetermined:
-      // We should have already asked for location authorization after presenting
-      // the "consent" screen during a redeem flow. But the SDK is telling us we
-      // haven't asked, so let's ask now.
-      CLLocationManager().requestWhenInUseAuthorization()
+  extension AppDelegate : MessagingDelegate {
 
-    case .locationNotAuthorized:
-      NSLog("App is not authorized to receive location updates")
-      
-    default: ()
-    }
-  }
-}
-
-extension AppDelegate : UNUserNotificationCenterDelegate {
-
-  // Receive displayed notifications for iOS 10 devices.
-  func userNotificationCenter(_ center: UNUserNotificationCenter,
-                              willPresent notification: UNNotification,
-                              withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
-    let userInfo = notification.request.content.userInfo
-
-    // With swizzling disabled you must let Messaging know about the message, for Analytics
-    Messaging.messaging().appDidReceiveMessage(userInfo)
-
-    // Print message ID.
-    if let messageID = userInfo[gcmMessageIDKey] {
-      print("Message ID: \(messageID)")
+    // Note: This callback is fired at each app startup and whenever a new token
+    // is generated.
+    func messaging(_ messaging: Messaging, didReceiveRegistrationToken pushToken: String) {
+      print("Push token: \(pushToken)")
+      let dataDict:[String: String] = ["token": pushToken]
+      // "FCMToken" for firebase
+      NotificationCenter.default.post(name: Notification.Name("APNSToken"),
+                                      object: nil,
+                                      userInfo: dataDict)
+      FlyBuy.updatePushToken(pushToken)
     }
 
-    // Print full message.
-    print(userInfo)
-
-    completionHandler([.badge, .sound, .alert])
-  }
-
-  func userNotificationCenter(_ center: UNUserNotificationCenter,
-                              didReceive response: UNNotificationResponse,
-                              withCompletionHandler completionHandler: @escaping () -> Void) {
-    let userInfo = response.notification.request.content.userInfo
-
-    // Print message ID.
-    if let messageID = userInfo[gcmMessageIDKey] {
-      print("Message ID: \(messageID)")
+    // Receive data messages on iOS 10+ directly from FCM (bypassing APNs) when
+    // the app is in the foreground.  To enable direct data messages, you can set
+    // Messaging.messaging().shouldEstablishDirectChannel to true.
+    func messaging(_ messaging: Messaging, didReceive remoteMessage: MessagingRemoteMessage) {
+      FlyBuy.handleRemoteNotification(remoteMessage.appData)
+      print("Received data message: \(remoteMessage.appData)")
     }
-
-    // Print full message.
-    print(userInfo)
-
-    completionHandler()
   }
-}
-
-extension AppDelegate : MessagingDelegate {
-
-  // Note: This callback is fired at each app startup and whenever a new token
-  // is generated.
-  func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String) {
-    print("Firebase registration token: \(fcmToken)")
-    let dataDict:[String: String] = ["token": fcmToken]
-    NotificationCenter.default.post(name: Notification.Name("FCMToken"),
-                                    object: nil,
-                                    userInfo: dataDict)
-    FlyBuy.updatePushToken(fcmToken)
-  }
-
-  // Receive data messages on iOS 10+ directly from FCM (bypassing APNs) when
-  // the app is in the foreground.  To enable direct data messages, you can set
-  // Messaging.messaging().shouldEstablishDirectChannel to true.
-  func messaging(_ messaging: Messaging, didReceive remoteMessage: MessagingRemoteMessage) {
-    FlyBuy.handleRemoteNotification(remoteMessage.appData)
-    print("Received data message: \(remoteMessage.appData)")
-  }
-}

--- a/FlyBuy Example/FlyBuy Example.entitlements
+++ b/FlyBuy Example/FlyBuy Example.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+</dict>
+</plist>

--- a/Podfile
+++ b/Podfile
@@ -1,0 +1,9 @@
+platform :ios, "13.0"
+use_frameworks!
+
+target 'FlyBuy Example' do
+  pod 'Firebase/Analytics'
+  pod 'Firebase/Core'
+  pod 'Firebase/DynamicLinks'
+  pod 'Firebase/Messaging'
+end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,0 +1,133 @@
+PODS:
+  - Firebase/Analytics (6.27.0):
+    - Firebase/Core
+  - Firebase/Core (6.27.0):
+    - Firebase/CoreOnly
+    - FirebaseAnalytics (= 6.6.1)
+  - Firebase/CoreOnly (6.27.0):
+    - FirebaseCore (= 6.8.0)
+  - Firebase/DynamicLinks (6.27.0):
+    - Firebase/CoreOnly
+    - FirebaseDynamicLinks (~> 4.1.0)
+  - Firebase/Messaging (6.27.0):
+    - Firebase/CoreOnly
+    - FirebaseMessaging (~> 4.5.0)
+  - FirebaseAnalytics (6.6.1):
+    - FirebaseCore (~> 6.8)
+    - FirebaseInstallations (~> 1.4)
+    - GoogleAppMeasurement (= 6.6.1)
+    - GoogleUtilities/AppDelegateSwizzler (~> 6.0)
+    - GoogleUtilities/MethodSwizzler (~> 6.0)
+    - GoogleUtilities/Network (~> 6.0)
+    - "GoogleUtilities/NSData+zlib (~> 6.0)"
+    - nanopb (~> 1.30905.0)
+  - FirebaseCore (6.8.0):
+    - FirebaseCoreDiagnostics (~> 1.3)
+    - GoogleUtilities/Environment (~> 6.5)
+    - GoogleUtilities/Logger (~> 6.5)
+  - FirebaseCoreDiagnostics (1.4.0):
+    - GoogleDataTransportCCTSupport (~> 3.1)
+    - GoogleUtilities/Environment (~> 6.5)
+    - GoogleUtilities/Logger (~> 6.5)
+    - nanopb (~> 1.30905.0)
+  - FirebaseDynamicLinks (4.1.0):
+    - FirebaseCore (~> 6.8)
+  - FirebaseInstallations (1.4.0):
+    - FirebaseCore (~> 6.8)
+    - GoogleUtilities/Environment (~> 6.6)
+    - GoogleUtilities/UserDefaults (~> 6.6)
+    - PromisesObjC (~> 1.2)
+  - FirebaseInstanceID (4.4.0):
+    - FirebaseCore (~> 6.8)
+    - FirebaseInstallations (~> 1.0)
+    - GoogleUtilities/Environment (~> 6.5)
+    - GoogleUtilities/UserDefaults (~> 6.5)
+  - FirebaseMessaging (4.5.0):
+    - FirebaseCore (~> 6.8)
+    - FirebaseInstanceID (~> 4.3)
+    - GoogleUtilities/AppDelegateSwizzler (~> 6.5)
+    - GoogleUtilities/Environment (~> 6.5)
+    - GoogleUtilities/Reachability (~> 6.5)
+    - GoogleUtilities/UserDefaults (~> 6.5)
+    - Protobuf (>= 3.9.2, ~> 3.9)
+  - GoogleAppMeasurement (6.6.1):
+    - GoogleUtilities/AppDelegateSwizzler (~> 6.0)
+    - GoogleUtilities/MethodSwizzler (~> 6.0)
+    - GoogleUtilities/Network (~> 6.0)
+    - "GoogleUtilities/NSData+zlib (~> 6.0)"
+    - nanopb (~> 1.30905.0)
+  - GoogleDataTransport (6.2.1)
+  - GoogleDataTransportCCTSupport (3.2.0):
+    - GoogleDataTransport (~> 6.1)
+    - nanopb (~> 1.30905.0)
+  - GoogleUtilities/AppDelegateSwizzler (6.6.0):
+    - GoogleUtilities/Environment
+    - GoogleUtilities/Logger
+    - GoogleUtilities/Network
+  - GoogleUtilities/Environment (6.6.0):
+    - PromisesObjC (~> 1.2)
+  - GoogleUtilities/Logger (6.6.0):
+    - GoogleUtilities/Environment
+  - GoogleUtilities/MethodSwizzler (6.6.0):
+    - GoogleUtilities/Logger
+  - GoogleUtilities/Network (6.6.0):
+    - GoogleUtilities/Logger
+    - "GoogleUtilities/NSData+zlib"
+    - GoogleUtilities/Reachability
+  - "GoogleUtilities/NSData+zlib (6.6.0)"
+  - GoogleUtilities/Reachability (6.6.0):
+    - GoogleUtilities/Logger
+  - GoogleUtilities/UserDefaults (6.6.0):
+    - GoogleUtilities/Logger
+  - nanopb (1.30905.0):
+    - nanopb/decode (= 1.30905.0)
+    - nanopb/encode (= 1.30905.0)
+  - nanopb/decode (1.30905.0)
+  - nanopb/encode (1.30905.0)
+  - PromisesObjC (1.2.9)
+  - Protobuf (3.12.0)
+
+DEPENDENCIES:
+  - Firebase/Analytics
+  - Firebase/Core
+  - Firebase/DynamicLinks
+  - Firebase/Messaging
+
+SPEC REPOS:
+  trunk:
+    - Firebase
+    - FirebaseAnalytics
+    - FirebaseCore
+    - FirebaseCoreDiagnostics
+    - FirebaseDynamicLinks
+    - FirebaseInstallations
+    - FirebaseInstanceID
+    - FirebaseMessaging
+    - GoogleAppMeasurement
+    - GoogleDataTransport
+    - GoogleDataTransportCCTSupport
+    - GoogleUtilities
+    - nanopb
+    - PromisesObjC
+    - Protobuf
+
+SPEC CHECKSUMS:
+  Firebase: fc4cbf6f1592636431821ef9a3c557e4dfd9f268
+  FirebaseAnalytics: 0ea640473474f036cabbc2576e20c2d63671c92f
+  FirebaseCore: feda061cb1ee6d8ad4824f4a4a8ffbcfe284f595
+  FirebaseCoreDiagnostics: 4505e4d4009b1d93f605088ee7d7764d5f0d1c84
+  FirebaseDynamicLinks: 50cff91aff05347770be750dde61d3311ff7ffc8
+  FirebaseInstallations: 293f567159b6d66d1c990f13bb868066096c94ec
+  FirebaseInstanceID: 3b119bfe90e904851218159c9a4ecb847cc51d18
+  FirebaseMessaging: ad9e1a80ea64905e01a0ce1b3eb76a2944544151
+  GoogleAppMeasurement: 2fd5c5a56c069db635c8e7b92d4809a9591d0a69
+  GoogleDataTransport: 9a8a16f79feffc7f42096743de2a7c4815e84020
+  GoogleDataTransportCCTSupport: 489c1265d2c85b68187a83a911913d190012158d
+  GoogleUtilities: 39530bc0ad980530298e9c4af8549e991fd033b1
+  nanopb: c43f40fadfe79e8b8db116583945847910cbabc9
+  PromisesObjC: b48e0338dbbac2207e611750777895f7a5811b75
+  Protobuf: 2793fcd0622a00b546c60e7cbbcc493e043e9bb9
+
+PODFILE CHECKSUM: 7edd3c3ef37e8ac4b744810891577dba671ef6d5
+
+COCOAPODS: 1.9.3


### PR DESCRIPTION
Add Firebase libraries and code to handle both Firebase, or APNS. The example app can be updated to remove the firebase-specific code (will be highlighted by removing the library) if just APNS is wanted. Firebase is the most likely choice, so that code is shown in the example by default.